### PR TITLE
Fixed re-optimization time by reseting cycles

### DIFF
--- a/helper_monkey.py
+++ b/helper_monkey.py
@@ -285,6 +285,7 @@ def main(API_KEY, pair='BTC-USD', granularity=900, duration=7*24*60*60, cash_buf
             history_pd, history_array = get_historic_data(pair=pair, granularity=granularity)
             reframed = reframe_data(history_pd)
             best_strategy = optimize_strategy(reframed, buy_range = (1.0, 4.0, 0.25), risk_range=(1.0, 4.0, 0.25), chandelier=False)
+            cycle = 0
 
         # Check crypto status
         output = get_product_data(pair)


### PR DESCRIPTION
I noticed this behavior of repeatably trying to re-optimize after the set reframe_threshold, which in my case was 3 hours. 
![Screenshot from 2021-05-12 23-48-48](https://user-images.githubusercontent.com/44000930/118163722-30066c80-b3d7-11eb-841d-61a2e4b0c401.png)

I believe I fixed it by resetting cycles to 0 after the re-optimization is performed. Which gives the below behavior, notice there's 12 900 second waits which is equivalent to 3 hours before each re-optimization is performed.
![Screenshot from 2021-05-13 10-34-29](https://user-images.githubusercontent.com/44000930/118163929-647a2880-b3d7-11eb-8ba6-44631d9c16ec.png)

Please double check this is the intended behavior and that my solution doesn't have any unforeseen side affects.
